### PR TITLE
Add link to subscribe for newsletter to header

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -216,6 +216,16 @@ img {
   width: 100%;
 }
 
+.newsletter {
+  font-family: "Moche-regular";
+  font-size: 1.5em;
+  text-transform: uppercase;
+  position: absolute;
+  top: 0.5em;
+  right: 0.5em;
+  padding: 1em;
+}
+
 .logo {
   margin: auto;
   width: 40vw;

--- a/index.html
+++ b/index.html
@@ -3,6 +3,12 @@ layout: default
 ---
 
 <div class="header">
+  <div class="newsletter">
+    <a href="https://hydradx.substack.com/" target="_blank">
+      newsletter
+    </a>
+
+  </div>
   <div class="logo">
     <img alt="h7dra.dx" src="assets/fullframe-logo-no-gap.svg" />
     <div>cross-chain liquidity protocol built on substrate</div>


### PR DESCRIPTION
This PR adds a `newsletter` button to the header which will hopefully attract more user subscriptions.

Screenshot:
<img width="2302" alt="Screenshot 2021-03-12 at 15 16 37" src="https://user-images.githubusercontent.com/2530251/110954368-b6a3bc80-8348-11eb-88eb-fba83b90d403.png">